### PR TITLE
MORecordEpisodeStatistics return scalars when not VecEnv

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,4 +1,5 @@
 cython
+gymnasium
 sphinx
 myst-parser
 git+https://github.com/Farama-Foundation/Celshast#egg=furo

--- a/mo_gymnasium/envs/lunar_lander/__init__.py
+++ b/mo_gymnasium/envs/lunar_lander/__init__.py
@@ -1,4 +1,4 @@
-from gym.envs.registration import register
+from gymnasium.envs.registration import register
 
 
 register(

--- a/mo_gymnasium/envs/lunar_lander/lunar_lander.py
+++ b/mo_gymnasium/envs/lunar_lander/lunar_lander.py
@@ -1,8 +1,8 @@
 import math
 
 import numpy as np
-from gym import spaces
-from gym.envs.box2d.lunar_lander import (
+from gymnasium import spaces
+from gymnasium.envs.box2d.lunar_lander import (
     FPS,
     LEG_DOWN,
     MAIN_ENGINE_POWER,

--- a/mo_gymnasium/utils.py
+++ b/mo_gymnasium/utils.py
@@ -176,7 +176,35 @@ class MOSyncVectorEnv(SyncVectorEnv):
 
 
 class MORecordEpisodeStatistics(RecordEpisodeStatistics):
-    """This wrapper will keep track of cumulative rewards and episode lengths."""
+    """This wrapper will keep track of cumulative rewards and episode lengths.
+
+    After the completion of an episode, ``info`` will look like this::
+
+        >>> info = {
+        ...     "episode": {
+        ...         "r": "<cumulative reward (array)>",
+        ...         "dr": "<discounted reward (array)>",
+        ...         "l": "<episode length (scalar)>", # contrary to Gymnasium, these are not a numpy array
+        ...         "t": "<elapsed time since beginning of episode (scalar)>"
+        ...     },
+        ... }
+
+    For a vectorized environments the output will be in the form of::
+
+        >>> infos = {
+        ...     "final_observation": "<array of length num-envs>",
+        ...     "_final_observation": "<boolean array of length num-envs>",
+        ...     "final_info": "<array of length num-envs>",
+        ...     "_final_info": "<boolean array of length num-envs>",
+        ...     "episode": {
+        ...         "r": "<array of cumulative reward (2d array, shape (num_envs, dim_reward))>",
+        ...         "dr": "<array of discounted reward (2d array, shape (num_envs, dim_reward))>",
+        ...         "l": "<array of episode length (array)>",
+        ...         "t": "<array of elapsed time since beginning of episode (array)>"
+        ...     },
+        ...     "_episode": "<boolean array of length num-envs>"
+        ... }
+    """
 
     def __init__(self, env: gym.Env, gamma: float = 1.0, deque_size: int = 100):
         """This wrapper will keep track of cumulative rewards and episode lengths.
@@ -187,25 +215,28 @@ class MORecordEpisodeStatistics(RecordEpisodeStatistics):
             deque_size: The size of the buffers :attr:`return_queue` and :attr:`length_queue`
         """
         super().__init__(env, deque_size)
-        # Here we just override the standard implementation to extend to MO
+        # CHANGE: Here we just override the standard implementation to extend to MO
+        # We also take care of the case where the env is vectorized
         self.reward_dim = self.env.reward_space.shape[0]
-        self.multi_env_shape = (self.num_envs, self.reward_dim)
+        if self.is_vector_env:
+            self.rewards_shape = (self.num_envs, self.reward_dim)
+        else:
+            self.rewards_shape = (self.reward_dim,)
         self.gamma = gamma
 
     def reset(self, **kwargs):
         """Resets the environment using kwargs and resets the episode returns and lengths."""
         obs, info = super().reset(**kwargs)
-        self.episode_start_times = np.full(self.num_envs, time.perf_counter(), dtype=np.float32)
 
-        self.episode_returns = np.zeros(self.multi_env_shape, dtype=np.float32)
-        self.disc_episode_returns = np.zeros(self.multi_env_shape, dtype=np.float32)
+        # CHANGE: Here we just override the standard implementation to extend to MO
+        self.episode_returns = np.zeros(self.rewards_shape, dtype=np.float32)
+        self.disc_episode_returns = np.zeros(self.rewards_shape, dtype=np.float32)
 
-        self.episode_lengths = np.zeros(self.num_envs, dtype=np.int32)
         return obs, info
 
     def step(self, action):
         """Steps through the environment, recording the episode statistics."""
-        # This is the code from the RecordEpisodeStatistics wrapper from gym.
+        # This is very close the code from the RecordEpisodeStatistics wrapper from gym.
         (
             observations,
             rewards,
@@ -217,36 +248,43 @@ class MORecordEpisodeStatistics(RecordEpisodeStatistics):
             infos, dict
         ), f"`info` dtype is {type(infos)} while supported dtype is `dict`. This may be due to usage of other wrappers in the wrong order."
         self.episode_returns += rewards
-        # The discounted returns are also computed here
+        self.episode_lengths += 1
+
+        # CHANGE: The discounted returns are also computed here
         self.disc_episode_returns += rewards * np.repeat(self.gamma**self.episode_lengths, self.reward_dim).reshape(
             self.episode_returns.shape
         )
-        self.episode_lengths += 1
+
         dones = np.logical_or(terminations, truncations)
-        if np.isscalar(dones):
-            dones = np.array([dones])
         num_dones = np.sum(dones)
         if num_dones:
             if "episode" in infos or "_episode" in infos:
                 raise ValueError("Attempted to add episode stats when they already exist")
             else:
-                episode_return = np.zeros(self.multi_env_shape, dtype=np.float32)
-                disc_episode_return = np.zeros(self.multi_env_shape, dtype=np.float32)
-                for i in range(self.num_envs):
-                    if dones[i]:
-                        # Makes a deepcopy to avoid subsequent mutations
-                        episode_return[i] = deepcopy(self.episode_returns[i])
-                        disc_episode_return[i] = deepcopy(self.disc_episode_returns[i])
+                episode_return = np.zeros(self.rewards_shape, dtype=np.float32)
+                disc_episode_return = np.zeros(self.rewards_shape, dtype=np.float32)
+                if self.is_vector_env:
+                    for i in range(self.num_envs):
+                        if dones[i]:
+                            # CHANGE: Makes a deepcopy to avoid subsequent mutations
+                            episode_return[i] = deepcopy(self.episode_returns[i])
+                            disc_episode_return[i] = deepcopy(self.disc_episode_returns[i])
+                else:
+                    episode_return = deepcopy(self.episode_returns)
+                    disc_episode_return = deepcopy(self.disc_episode_returns)
+
+                length_eps = np.where(dones, self.episode_lengths, 0)
+                time_eps = np.where(
+                    dones,
+                    np.round(time.perf_counter() - self.episode_start_times, 6),
+                    0.0,
+                )
 
                 infos["episode"] = {
                     "r": episode_return,
                     "dr": disc_episode_return,
-                    "l": np.where(dones, self.episode_lengths, 0),
-                    "t": np.where(
-                        dones,
-                        np.round(time.perf_counter() - self.episode_start_times, 6),
-                        0.0,
-                    ),
+                    "l": length_eps[0] if not self.is_vector_env else length_eps,
+                    "t": time_eps[0] if not self.is_vector_env else time_eps,
                 }
                 if self.is_vector_env:
                     infos["_episode"] = np.where(dones, True, False)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ classifiers = [
     'Topic :: Scientific/Engineering :: Artificial Intelligence',
 ]
 dependencies = [
-    "gymnasium >=0.26",
+    "gymnasium >=0.27",
     "numpy >=1.21.0",
     "pygame >=2.1.0",
     "scipy >=1.7.3",

--- a/tests/test_wrappers.py
+++ b/tests/test_wrappers.py
@@ -95,16 +95,16 @@ def test_mo_record_ep_statistic():
 
     assert isinstance(info["episode"]["r"], np.ndarray)
     assert isinstance(info["episode"]["dr"], np.ndarray)
-    assert info["episode"]["r"].shape == (1, 2)
-    assert info["episode"]["dr"].shape == (1, 2)
-    assert tuple(info["episode"]["r"][0]) == (np.float32(8.2), np.float32(-3.0))
-    assert tuple(np.round(info["episode"]["dr"][0], 4)) == (
-        np.float32(7.7154),
-        np.float32(-2.9109),
+    assert info["episode"]["r"].shape == (2,)
+    assert info["episode"]["dr"].shape == (2,)
+    assert tuple(info["episode"]["r"]) == (np.float32(8.2), np.float32(-3.0))
+    assert tuple(np.round(info["episode"]["dr"], 2)) == (
+        np.float32(7.48),
+        np.float32(-2.82),
     )
-    assert isinstance(info["episode"]["l"][0], np.int32)
-    assert info["episode"]["l"][0] == 3
-    assert isinstance(info["episode"]["t"][0], np.float32)
+    assert isinstance(info["episode"]["l"], np.int32)
+    assert info["episode"]["l"] == 3
+    assert isinstance(info["episode"]["t"], np.float32)
 
 
 def test_mo_record_ep_statistic_vector_env():


### PR DESCRIPTION
Fix #28 

The wrapper was wrapping all infos in numpy arrays (like time and episode length), even when the environments where not vectorized. This didn't make sense and was a behaviour change compared to 0.2.1. Hence the revert here.

Note: this is not the current behaviour of Gymnasium (they do return numpy arrays, hence our behaviour change), but they will change it in the future.