### PR TITLE
Add continuous lunar lander and 2d hopper

### DIFF
--- a/mo_gymnasium/envs/lunar_lander/__init__.py
+++ b/mo_gymnasium/envs/lunar_lander/__init__.py
@@ -6,3 +6,10 @@ register(
     entry_point="mo_gymnasium.envs.lunar_lander.lunar_lander:MOLunarLander",
     max_episode_steps=1000,
 )
+
+register(
+    id="mo-lunar-lander-continuous-v2",
+    entry_point="mo_gymnasium.envs.lunar_lander.lunar_lander:MOLunarLander",
+    max_episode_steps=1000,
+    continuous=True,
+)

--- a/mo_gymnasium/envs/mujoco/__init__.py
+++ b/mo_gymnasium/envs/mujoco/__init__.py
@@ -14,6 +14,13 @@ register(
 )
 
 register(
+    id="mo-hopper-2d-v4",
+    entry_point="mo_gymnasium.envs.mujoco.hopper:MOHopperEnv",
+    max_episode_steps=1000,
+    cost_objective=False,
+)
+
+register(
     id="mo-reacher-v4",
     entry_point="mo_gymnasium.envs.mujoco.reacher:MOReacherEnv",
     max_episode_steps=50,


### PR DESCRIPTION
As discussed, it makes it easier to avoid ambiguity to register parameterized envs with a dedicated key.