### PR TITLE
Added handling for actions in numpy array format.

### DIFF
--- a/mo_gymnasium/envs/deep_sea_treasure/deep_sea_treasure.py
+++ b/mo_gymnasium/envs/deep_sea_treasure/deep_sea_treasure.py
@@ -265,6 +265,7 @@ class DeepSeaTreasure(gym.Env, EzPickle):
         return state, {}
 
     def step(self, action):
+        action = self._convert_action(action)
         next_state = self.current_state + self.dir[action]
 
         if self._is_valid_state(next_state):
@@ -283,6 +284,12 @@ class DeepSeaTreasure(gym.Env, EzPickle):
         if self.render_mode == "human":
             self.render()
         return state, vec_reward, terminal, False, {}
+
+    def _convert_action(self, action):
+        if isinstance(action, int):
+            return action
+        elif isinstance(action, (np.generic, np.ndarray)) and (np.issubdtype(action.dtype, np.integer) and action.shape == ()):
+            return np.int64(action)
 
     def close(self):
         if self.window is not None:


### PR DESCRIPTION
As per the code level spec here https://github.com/Farama-Foundation/Gymnasium/blob/main/gymnasium/spaces/discrete.py, numpy arrays with a single value conform to the Discrete action space. It caused some issues when I tested out a wrapper in another library which always sent in numpy arrays (torchrl). 
The alternative approach would be to redesign the use of the dir dictionary but that could impact more users. Let me know if I should go another direction, add tests etc (I have some locally but this type of testing should probably be broader across environments).