### PR TITLE
Add warning for order of wrapping in the MORecordEpisodeStatistics Wrapper

### DIFF
--- a/mo_gymnasium/utils.py
+++ b/mo_gymnasium/utils.py
@@ -195,7 +195,7 @@ class MORecordEpisodeStatistics(RecordEpisodeStatistics, EzPickle):
         ...     },
         ... }
 
-    For a vectorized environments the output will be in the form of::
+    For a vectorized environments the output will be in the form of (be careful to first wrap the env into vector before applying MORewordStatistics)::
 
         >>> infos = {
         ...     "final_observation": "<array of length num-envs>",


### PR DESCRIPTION
The `MORecordEpisodeStatististics` wrapper does not return the same thing with vector envs depending on if it is wrapper before or after.

The right order is: 
```python
env = VectorEnv(...)
env = MORecordEpisodeStatistic(env)
```

I added a note in the doc to avoid confusion. 

This will change when Gymnasium has the new vector envs so I do not plan to make effort to support the other way around.