### PR TITLE
Add Gymnasium performance improvement to Lunar Lander

### DIFF
--- a/mo_gymnasium/envs/lunar_lander/lunar_lander.py
+++ b/mo_gymnasium/envs/lunar_lander/lunar_lander.py
@@ -124,12 +124,14 @@ class MOLunarLander(LunarLander):  # no need for EzPickle, it's already in Lunar
                 self.lander.position[0] + ox - tip[0] * 17 / SCALE,
                 self.lander.position[1] + oy + tip[1] * SIDE_ENGINE_HEIGHT / SCALE,
             )
-            p = self._create_particle(0.7, impulse_pos[0], impulse_pos[1], s_power)
-            p.ApplyLinearImpulse(
-                (ox * SIDE_ENGINE_POWER * s_power, oy * SIDE_ENGINE_POWER * s_power),
-                impulse_pos,
-                True,
-            )
+            if self.render_mode is not None:
+                # particles are just a decoration, so don't add them when not rendering
+                p = self._create_particle(0.7, impulse_pos[0], impulse_pos[1], s_power)
+                p.ApplyLinearImpulse(
+                    (ox * SIDE_ENGINE_POWER * s_power, oy * SIDE_ENGINE_POWER * s_power),
+                    impulse_pos,
+                    True,
+                )
             self.lander.ApplyLinearImpulse(
                 (-ox * SIDE_ENGINE_POWER * s_power, -oy * SIDE_ENGINE_POWER * s_power),
                 impulse_pos,


### PR DESCRIPTION
https://github.com/Farama-Foundation/Gymnasium/pull/235 found a significant performance improvement to Lunar Lander

Using `benchmark_step`, the gymnasium environment achieves `~15000` steps per second (on my laptop), while mo-gymnasium currently achieves `~6500`.

```python
from gymnasium.utils.performance import benchmark_step
import mo_gymnasium

env = mo_gymnasium.make("LunarLander-v2")
mo_env = mo_gymnasium.make("mo-lunar-lander-v2")

print('env benchmark', benchmark_step(env, target_duration=15))
print('mo-env benchmark', benchmark_step(mo_env, target_duration=15))
```

This update achieves `~8000` which is still significant performance difference, which should be investigated further  