### PR TITLE
breakable-bottles observation space correction

### DIFF
--- a/mo_gymnasium/envs/breakable_bottles/breakable_bottles.py
+++ b/mo_gymnasium/envs/breakable_bottles/breakable_bottles.py
@@ -27,8 +27,8 @@ class BreakableBottles(Env, EzPickle):
     - bottles_carrying: the number of bottles the agent is currently carrying (0, 1 or 2)
     - bottles_delivered: the number of bottles the agent has delivered (0, 1 or 2)
     - bottles_dropped: for each location, a boolean flag indicating if that location currently contains a bottle
-    
-    Note that this observation space is different from that listed in the paper above. In the paper, bottles_delivered's possible values are listed as (0 or 1), 
+
+    Note that this observation space is different from that listed in the paper above. In the paper, bottles_delivered's possible values are listed as (0 or 1),
     rather than (0, 1 or 2). This is because the paper did not take the terminal state, in which 2 bottles have been delivered, into account when calculating
     the observation space. As such, the observation space of this implementation is larger than specified in the paper, having 360 possible states instead of 240.
 

--- a/mo_gymnasium/envs/breakable_bottles/breakable_bottles.py
+++ b/mo_gymnasium/envs/breakable_bottles/breakable_bottles.py
@@ -25,7 +25,7 @@ class BreakableBottles(Env, EzPickle):
     The observation space is a dictionary with 4 keys:
     - location: the current location of the agent
     - bottles_carrying: the number of bottles the agent is currently carrying (0, 1 or 2)
-    - bottles_delivered: the number of bottles the agent has delivered (0 or 1)
+    - bottles_delivered: the number of bottles the agent has delivered (0, 1 or 2)
     - bottles_dropped: for each location, a boolean flag indicating if that location currently contains a bottle
 
     ## Reward Space
@@ -96,11 +96,11 @@ class BreakableBottles(Env, EzPickle):
             {
                 "location": Discrete(self.size),
                 "bottles_carrying": Discrete(3),
-                "bottles_delivered": Discrete(2),
+                "bottles_delivered": Discrete(3),
                 "bottles_dropped": MultiBinary(self.size - 2),
             }
         )
-        self.num_observations = 240
+        self.num_observations = 360
 
         self.action_space = Discrete(3)  # LEFT, RIGHT, PICKUP
         self.num_actions = 3

--- a/mo_gymnasium/envs/breakable_bottles/breakable_bottles.py
+++ b/mo_gymnasium/envs/breakable_bottles/breakable_bottles.py
@@ -27,6 +27,10 @@ class BreakableBottles(Env, EzPickle):
     - bottles_carrying: the number of bottles the agent is currently carrying (0, 1 or 2)
     - bottles_delivered: the number of bottles the agent has delivered (0, 1 or 2)
     - bottles_dropped: for each location, a boolean flag indicating if that location currently contains a bottle
+    
+    Note that this observation space is different from that listed in the paper above. In the paper, bottles_delivered's possible values are listed as (0 or 1), 
+    rather than (0, 1 or 2). This is because the paper did not take the terminal state, in which 2 bottles have been delivered, into account when calculating
+    the observation space. As such, the observation space of this implementation is larger than specified in the paper, having 360 possible states instead of 240.
 
     ## Reward Space
     The reward space has 3 dimensions:
@@ -220,7 +224,7 @@ class BreakableBottles(Env, EzPickle):
                 *[[bd > 0] for bd in obs["bottles_dropped"]],
             ]
         )
-        return np.ravel_multi_index(multi_index, tuple([self.size, 3, 2, *([2] * (self.size - 2))]))
+        return np.ravel_multi_index(multi_index, tuple([self.size, 3, 3, *([2] * (self.size - 2))]))
 
     def _get_obs(self):
         return {


### PR DESCRIPTION
The breakable-bottles environment's observation space's "bottles_delivered" subspace is a Discrete(2) (so, 0 or 1 values allowed), but on the step when the goal state is reached, the agent has delivered 2 bottles, and an observation with that info is returned. This violates the stated observation space. This PR changes the subspace to be a Discrete(3), and updates the docs and num_observations member accordingly.

This is my first ever Github PR so I apologise if I have done anything incorrect or impolite in this process, and thank you for the project!