### PR TITLE
Deep sea treasure We have found that there is an error in the _is_valid_state of the environment.

### DIFF
--- a/mo_gymnasium/envs/deep_sea_treasure/deep_sea_treasure.py
+++ b/mo_gymnasium/envs/deep_sea_treasure/deep_sea_treasure.py
@@ -212,10 +212,16 @@ class DeepSeaTreasure(gym.Env, EzPickle):
         return self.sea_map[pos[0]][pos[1]]
 
     def _is_valid_state(self, state):
-        if state[0] >= 0 and state[0] <= 10 and state[1] >= 0 and state[1] <= 10:
-            if self._get_map_value(state) != -10:
-                return True
-        return False
+        if self.map_name == "mirrored":
+            if state[0] >= 0 and state[0] <= 10 and state[1] >= 0 and state[1] <= 19:
+                if self._get_map_value(state) != -10:
+                    return True
+            return False
+        else:
+            if state[0] >= 0 and state[0] <= 10 and state[1] >= 0 and state[1] <= 10:
+                if self._get_map_value(state) != -10:
+                    return True
+            return False
 
     def render(self):
         if self.render_mode is None:


### PR DESCRIPTION
Deep sea treasure I found that there was an error in the _is_valid_state of the environment. In the MIRRORED environment, the x-coordinate is from 0 to 19, but the _is_valid_state was set so that the x-coordinate can only be from 0 to 10. Validate was modified as follows.
```python
    def _is_valid_state(self, state):
        if self.map_name == "mirrored":
            if state[0] >= 0 and state[0] <= 10 and state[1] >= 0 and state[1] <= 19:
                if self._get_map_value(state) != -10:
                    return True
            return False
        else:
            if state[0] >= 0 and state[0] <= 10 and state[1] >= 0 and state[1] <= 10:
                if self._get_map_value(state) != -10:
                    return True
            return False
```