### PR TITLE
Bugfix Four Room rendering

### DIFF
--- a/mo_gymnasium/envs/four_room/four_room.py
+++ b/mo_gymnasium/envs/four_room/four_room.py
@@ -179,12 +179,15 @@ class FourRoom(gym.Env, EzPickle):
         # can now move
         self.state = (s1, collected)
 
+        if self.render_mode == "human":
+            self.render()
+
         # into a goal cell
         if s1 == self.goal:
             phi = np.ones(len(self.all_shapes), dtype=np.float32)
             terminated = True
             return self.state_to_array(self.state), phi, terminated, False, {}
-
+            
         # into a shape cell
         if s1 in self.shape_ids:
             shape_id = self.shape_ids[s1]
@@ -205,9 +208,6 @@ class FourRoom(gym.Env, EzPickle):
                 self.state = (s1, collected)
                 phi = self.features(old_state, action, self.state)
                 return self.state_to_array(self.state), phi, terminated, False, {}
-
-        if self.render_mode == "human":
-            self.render()
 
         # into an empty cell
         return (

--- a/mo_gymnasium/envs/four_room/four_room.py
+++ b/mo_gymnasium/envs/four_room/four_room.py
@@ -187,7 +187,7 @@ class FourRoom(gym.Env, EzPickle):
             phi = np.ones(len(self.all_shapes), dtype=np.float32)
             terminated = True
             return self.state_to_array(self.state), phi, terminated, False, {}
-            
+
         # into a shape cell
         if s1 in self.shape_ids:
             shape_id = self.shape_ids[s1]


### PR DESCRIPTION
Four Room doesn't render in human mode when entering a shape space or goal space, even after the shape has been collected. Moving the render to before the checks occur will render in these cases.