### PR TITLE
Fix Minecart Convex Coverage Set calculation (Issue #129)

### DIFF
--- a/mo_gymnasium/envs/minecart/__init__.py
+++ b/mo_gymnasium/envs/minecart/__init__.py
@@ -4,13 +4,13 @@ from gymnasium.envs.registration import register
 
 
 register(
-    id="minecart-v0",
+    id="minecart-v1",
     entry_point="mo_gymnasium.envs.minecart.minecart:Minecart",
     max_episode_steps=1000,
 )
 
 register(
-    id="minecart-rgb-v0",
+    id="minecart-rgb-v1",
     entry_point="mo_gymnasium.envs.minecart.minecart:Minecart",
     kwargs={"image_observation": True},
     nondeterministic=True,  # This is a nondeterministic environment due to the random placement of the mines
@@ -18,7 +18,7 @@ register(
 )
 
 register(
-    id="minecart-deterministic-v0",
+    id="minecart-deterministic-v1",
     entry_point="mo_gymnasium.envs.minecart.minecart:Minecart",
     kwargs={"config": str(Path(__file__).parent.absolute()) + "/mine_config_det.json"},
     max_episode_steps=1000,

--- a/mo_gymnasium/envs/minecart/minecart.py
+++ b/mo_gymnasium/envs/minecart/minecart.py
@@ -16,6 +16,7 @@ from gymnasium.utils import EzPickle
 from paretoset import paretoset
 from scipy.optimize import linprog
 
+
 EPS_SPEED = 0.001  # Minimum speed to be considered in motion
 HOME_X = 0.0
 HOME_Y = 0.0

--- a/mo_gymnasium/envs/minecart/minecart.py
+++ b/mo_gymnasium/envs/minecart/minecart.py
@@ -201,18 +201,19 @@ class Minecart(gym.Env, EzPickle):
         )
         self.reward_dim = self.ore_cnt + 1
 
-    def convex_coverage_set(self, gamma: float, symmetric: bool = True) -> List[np.ndarray]:
+    def convex_coverage_set(self, gamma: float, symmetric: bool = True, batch_size: int = 10**5) -> List[np.ndarray]:
         """
         Computes an approximate convex coverage set (CCS).
 
         Args:
             gamma (float): Discount factor to apply to rewards.
             symmetric (bool): If true, we assume the pattern of accelerations from the base to the mine is the same as from the mine to the base. Default: True
+            batch_size (int): The number of trajectory rewards to store before computing a batch of pareto points. Default: 10**5
 
         Returns:
             The convex coverage set
         """
-        policies = self.pareto_front(gamma, symmetric)
+        policies = self.pareto_front(gamma, symmetric, batch_size)
         origin = np.min(policies, axis=0)
         extended_policies = [origin] + policies
         return [policies[idx - 1] for idx in ConvexHull(extended_policies).vertices if idx != 0]

--- a/mo_gymnasium/envs/minecart/minecart.py
+++ b/mo_gymnasium/envs/minecart/minecart.py
@@ -216,18 +216,19 @@ class Minecart(gym.Env, EzPickle):
         extended_policies = [origin] + policies
         return [policies[idx - 1] for idx in ConvexHull(extended_policies).vertices if idx != 0]
 
-    def pareto_front(self, gamma: float, symmetric: bool = True) -> List[np.ndarray]:
+    def pareto_front(self, gamma: float, symmetric: bool = True, batch_size: int = 10**3) -> List[np.ndarray]:
         """
         Computes an approximate pareto front.
 
         Args:
             gamma (float): Discount factor to apply to rewards
             symmetric (bool): If true, we assume the pattern of accelerations from the base to the mine is the same as from the mine to the base. Default: True
-
+            batch_size (int): The number of trajectory rewards to store before computing a batch of pareto points. Default: 10**3
         Returns:
             The pareto coverage set
         """
-        all_rewards = []
+        rewards_batch = []
+        pareto_rewards = []
         base_perimeter = BASE_RADIUS * BASE_SCALE
 
         # Empty mine just outside the base
@@ -389,11 +390,17 @@ class Minecart(gym.Env, EzPickle):
                 reward[-1, :-1] = mine_means * mine_actions / max(1, (mn_sum * mine_actions) / self.capacity)
 
                 reward = np.dot(discount_map[: len(s)], reward)
-                all_rewards.append(reward)
+                rewards_batch.append(reward)
 
-            all_rewards = pareto_filter(all_rewards, minimize=False)
+                if len(rewards_batch) >= batch_size:
+                    pareto_batch = pareto_filter(rewards_batch, minimize=False)
+                    pareto_rewards.extend(pareto_batch)
+                    rewards_batch = []
+            
+        pareto_rewards.extend(rewards_batch)
+        pareto_rewards = pareto_filter(pareto_rewards, minimize=False)
 
-        return all_rewards
+        return pareto_rewards
 
     def generate_mines(self, mine_distributions=None):
         """

--- a/mo_gymnasium/envs/minecart/minecart.py
+++ b/mo_gymnasium/envs/minecart/minecart.py
@@ -228,8 +228,9 @@ class Minecart(gym.Env, EzPickle):
         Returns:
             The pareto coverage set
         """
-        rewards_batch = []
-        pareto_rewards = []
+        idx = 0
+        rewards_batch = np.empty(shape=(batch_size, self.reward_dim))
+        pareto_batches = []
         base_perimeter = BASE_RADIUS * BASE_SCALE
 
         # Empty mine just outside the base
@@ -391,18 +392,19 @@ class Minecart(gym.Env, EzPickle):
                 reward[-1, :-1] = mine_means * mine_actions / max(1, (mn_sum * mine_actions) / self.capacity)
 
                 reward = np.dot(discount_map[: len(s)], reward)
-                rewards_batch.append(reward)
+                rewards_batch[idx] = reward
+                idx += 1
 
-                if len(rewards_batch) >= batch_size:
-                    rewards_arr = np.array(rewards_batch)
-                    pareto_mask = paretoset(rewards_arr, sense=["max"] * self.reward_dim)
-                    pareto_rewards.extend(rewards_arr[pareto_mask])
-                    rewards_batch = []
+                if idx >= batch_size:
+                    pareto_mask = paretoset(rewards_batch, sense=["max"] * self.reward_dim)
+                    pareto_batches.append(rewards_batch[pareto_mask])
+                    rewards_batch = np.empty(shape=(batch_size, self.reward_dim))
+                    idx = 0
 
-        pareto_rewards.extend(rewards_batch)
-        pareto_arr = np.array(pareto_rewards)
-        pareto_mask = paretoset(pareto_arr, sense=["max"] * self.reward_dim)
-        pareto_rewards = list(pareto_arr[pareto_mask])
+        pareto_batches.append(rewards_batch[:idx])
+        pareto_concat = np.concatenate(pareto_batches, axis=0)
+        pareto_mask = paretoset(pareto_concat, sense=["max"] * self.reward_dim)
+        pareto_rewards = list(pareto_concat[pareto_mask])
 
         return pareto_rewards
 

--- a/mo_gymnasium/envs/minecart/minecart.py
+++ b/mo_gymnasium/envs/minecart/minecart.py
@@ -213,8 +213,7 @@ class Minecart(gym.Env, EzPickle):
         threshold: float = 0.0,
         on_error: Literal["warn", "raise", "ignore"] = "warn",
     ) -> tuple[np.ndarray, pd.DataFrame]:
-        """
-        Computes an approximate convex coverage set (CCS) by determining which reward vectors are linearly maximizable.
+        """Computes an approximate convex coverage set (CCS) by determining which reward vectors are linearly maximizable.
 
         A point p_i is linearly maximizable if there exists a weight vector v (non-negative, summing to 1) such that
         p_i @ v >= p_j @ v for all j != i. Equivalently, if margin is the maximum value that satisfies
@@ -231,7 +230,7 @@ class Minecart(gym.Env, EzPickle):
                 Default: 10**5
             include_coplanar: If True, points that tie for maximality are included (margin >= 0). If False, only points that
                 are uniquely maximal are included (margin > threshold).
-            threshold: minimum margin threshold for strict maximizability. Default: 0.0
+            threshold: Minimum margin threshold for strict maximizability. Default: 0.0
             on_error: Action to take if linprog fails to find a solution (status != 0). Default: "warn"
                 "warn"   - issue a warning and leave the corresponding weights and margin as NaN.
                 "raise"  - raise a RuntimeError.
@@ -241,9 +240,9 @@ class Minecart(gym.Env, EzPickle):
             A tuple containing:
                 - convex_rewards (np.ndarray): Reward values ("Ore_1", ..., "Ore_n", "Fuel") of convex coverage set.
                 - df_convex (pd.DataFrame): Convex coverage set with rewards columns ("Ore_1", ..., "Ore_n", "Fuel"),
-                "Mine_Position", "Action_Sequence", weight columns ("Weight_Ore_1", ..., "Weight_Ore_n", "Weight_Fuel"),
-                and "Margin". Weight columns correspond to the components of the weight vector v that maximizes the margin
-                for each point. "Margin" column contains the maximum achievable margin for each point.
+                    "Mine_Position", "Action_Sequence", weight columns ("Weight_Ore_1", ..., "Weight_Ore_n", "Weight_Fuel"),
+                    and "Margin". Weight columns correspond to the components of the weight vector v that maximizes the margin
+                    for each point. "Margin" column contains the maximum achievable margin for each point.
         """
         pareto_rewards, df_pareto = self.pareto_front(gamma, symmetric, batch_size)
         coplanar_mask, strict_mask, weights, margins = check_linear_maximizability(
@@ -266,18 +265,20 @@ class Minecart(gym.Env, EzPickle):
         return convex_rewards, df_convex
 
     def pareto_front(self, gamma: float, symmetric: bool = True, batch_size: int = 10**5) -> tuple[np.ndarray, pd.DataFrame]:
-        """
-        Computes an approximate pareto front.
+        """Computes an approximate pareto front.
 
         Args:
-            gamma (float): Discount factor to apply to rewards symmetric (bool): If true, we assume the pattern of
-            accelerations from the base to the mine is the same as from the mine to the base. Default: True
-            batch_size (int): The number of trajectory rewards to store before computing a batch of pareto points. Default: 10**5
+            gamma: Discount factor to apply to rewards.
+            symmetric: If true, we assume the pattern of accelerations from the base to the mine is the same as from
+                the mine to the base. Default: True
+            batch_size: The number of trajectory rewards to store before computing a batch of pareto points.
+                Default: 10**5
+
         Returns:
             A tuple containing:
                 - pareto_rewards (np.ndarray): Reward values ("Ore_1", ..., "Ore_n", "Fuel") of pareto front.
                 - df_pareto (pd.DataFrame): Pareto front with reward columns ("Ore_1", ..., "Ore_n", "Fuel"),
-                "Mine_Position", and "Action_Sequence".
+                    "Mine_Position", and "Action_Sequence".
         """
         idx = 0
         rewards_batch = np.empty(shape=(batch_size, self.reward_dim), dtype=np.float64)
@@ -903,8 +904,7 @@ def truncated_mean(mean, std, a, b):
 def check_linear_maximizability(
     points: np.ndarray, threshold: float = 0.0, on_error: Literal["warn", "raise", "ignore"] = "warn"
 ) -> tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
-    """
-    Determine which reward vectors are linearly maximizable.
+    """Determine which reward vectors are linearly maximizable.
 
     A point p_i is linearly maximizable if there exists a weight vector v (non-negative, summing to 1) such that
     p_i @ v >= p_j @ v for all j != i. Equivalently, if margin is the maximum value that satisfies

--- a/mo_gymnasium/envs/minecart/minecart.py
+++ b/mo_gymnasium/envs/minecart/minecart.py
@@ -11,6 +11,7 @@ import pygame
 import scipy.stats
 from gymnasium.spaces import Box, Discrete
 from gymnasium.utils import EzPickle
+from paretoset import paretoset
 from scipy.spatial import ConvexHull
 
 
@@ -216,14 +217,14 @@ class Minecart(gym.Env, EzPickle):
         extended_policies = [origin] + policies
         return [policies[idx - 1] for idx in ConvexHull(extended_policies).vertices if idx != 0]
 
-    def pareto_front(self, gamma: float, symmetric: bool = True, batch_size: int = 10**3) -> List[np.ndarray]:
+    def pareto_front(self, gamma: float, symmetric: bool = True, batch_size: int = 10**5) -> List[np.ndarray]:
         """
         Computes an approximate pareto front.
 
         Args:
             gamma (float): Discount factor to apply to rewards
             symmetric (bool): If true, we assume the pattern of accelerations from the base to the mine is the same as from the mine to the base. Default: True
-            batch_size (int): The number of trajectory rewards to store before computing a batch of pareto points. Default: 10**3
+            batch_size (int): The number of trajectory rewards to store before computing a batch of pareto points. Default: 10**5
         Returns:
             The pareto coverage set
         """
@@ -393,12 +394,15 @@ class Minecart(gym.Env, EzPickle):
                 rewards_batch.append(reward)
 
                 if len(rewards_batch) >= batch_size:
-                    pareto_batch = pareto_filter(rewards_batch, minimize=False)
-                    pareto_rewards.extend(pareto_batch)
+                    rewards_arr = np.array(rewards_batch)
+                    pareto_mask = paretoset(rewards_arr, sense=["max"] * self.reward_dim)
+                    pareto_rewards.extend(rewards_arr[pareto_mask])
                     rewards_batch = []
-            
+
         pareto_rewards.extend(rewards_batch)
-        pareto_rewards = pareto_filter(pareto_rewards, minimize=False)
+        pareto_arr = np.array(pareto_rewards)
+        pareto_mask = paretoset(pareto_arr, sense=["max"] * self.reward_dim)
+        pareto_rewards = list(pareto_arr[pareto_mask])
 
         return pareto_rewards
 
@@ -833,29 +837,6 @@ def truncated_mean(mean, std, a, b):
 
     trunc_mean = mean + ((phia - phib) / (PHIB - PHIA)) * std
     return trunc_mean
-
-
-def pareto_filter(costs, minimize=True):
-    """
-    Find the pareto-efficient points
-    :param costs: An (n_points, n_costs) array
-    :param return_mask: True to return a mask
-    :return: An array of indices of pareto-efficient points.
-        If return_mask is True, this will be an (n_points, ) boolean array
-        Otherwise it will be a (n_efficient_points, ) integer array of indices.
-    from https://stackoverflow.com/a/40239615
-    """
-    costs_copy = np.copy(costs) if minimize else -np.copy(costs)
-    is_efficient = np.arange(costs_copy.shape[0])
-    next_point_index = 0  # Next index in the is_efficient array to search for
-    while next_point_index < len(costs_copy):
-        nondominated_point_mask = np.any(costs_copy < costs_copy[next_point_index], axis=1)
-        nondominated_point_mask[next_point_index] = True
-        # Remove dominated points
-        is_efficient = is_efficient[nondominated_point_mask]
-        costs_copy = costs_copy[nondominated_point_mask]
-        next_point_index = np.sum(nondominated_point_mask[:next_point_index]) + 1
-    return [costs[i] for i in is_efficient]
 
 
 if __name__ == "__main__":

--- a/mo_gymnasium/envs/minecart/minecart.py
+++ b/mo_gymnasium/envs/minecart/minecart.py
@@ -7,6 +7,7 @@ from typing import List, Optional
 
 import gymnasium as gym
 import numpy as np
+import pandas as pd
 import pygame
 import scipy.stats
 from gymnasium.spaces import Box, Discrete
@@ -170,6 +171,7 @@ class Minecart(gym.Env, EzPickle):
             )
             for i in range(self.ore_cnt)
         ]
+        self.reward_names = ["Ore" + str(i + 1) for i in range(self.ore_cnt)] + ["Fuel"]
         self.generate_mines(None)
 
         if "mines" in data:
@@ -201,7 +203,7 @@ class Minecart(gym.Env, EzPickle):
         )
         self.reward_dim = self.ore_cnt + 1
 
-    def convex_coverage_set(self, gamma: float, symmetric: bool = True, batch_size: int = 10**5) -> np.ndarray:
+    def convex_coverage_set(self, gamma: float, symmetric: bool = True, batch_size: int = 10**5) -> pd.DataFrame:
         """
         Computes an approximate convex coverage set (CCS).
 
@@ -213,15 +215,17 @@ class Minecart(gym.Env, EzPickle):
         Returns:
             The convex coverage set
         """
-        policies = self.pareto_front(gamma, symmetric, batch_size)
-        origin = np.min(policies, axis=0)
-        extended_policies = np.concatenate([[origin], policies], axis=0)
-        hull = ConvexHull(extended_policies)
-        vertices = hull.vertices[hull.vertices != 0]
-        convex_policies = hull.points[vertices]
-        return convex_policies
+        df_pareto = self.pareto_front(gamma, symmetric, batch_size)
+        pareto_rewards = df_pareto[self.reward_names].values
+        origin = np.min(pareto_rewards, axis=0)
+        extended_rewards = np.concatenate([pareto_rewards, [origin]], axis=0)
+        origin_idx = len(extended_rewards) - 1
+        hull = ConvexHull(extended_rewards)
+        vertices = hull.vertices[hull.vertices != origin_idx]
+        df_convex = df_pareto.iloc[vertices]
+        return df_convex
 
-    def pareto_front(self, gamma: float, symmetric: bool = True, batch_size: int = 10**5) -> np.ndarray:
+    def pareto_front(self, gamma: float, symmetric: bool = True, batch_size: int = 10**5) -> pd.DataFrame:
         """
         Computes an approximate pareto front.
 
@@ -233,7 +237,9 @@ class Minecart(gym.Env, EzPickle):
             The pareto coverage set
         """
         idx = 0
-        rewards_batch = np.empty(shape=(batch_size, self.reward_dim))
+        rewards_batch = np.empty(shape=(batch_size, self.reward_dim), dtype=np.float64)
+        mine_pos_batch = np.empty(shape=(batch_size,), dtype=object)
+        action_seq_batch = np.empty(shape=(batch_size,), dtype=object)
         pareto_batches = []
         base_perimeter = BASE_RADIUS * BASE_SCALE
 
@@ -389,28 +395,38 @@ class Minecart(gym.Env, EzPickle):
                 + longest_pattern
             )
             discount_map = gamma ** np.arange(max_len)
-            for s in all_sequences:
-                reward = np.zeros((len(s), self.reward_dim))
-                reward[:, -1] = fuel_costs[s]
-                mine_actions = s.count(ACT_MINE)
+            for seq in all_sequences:
+                reward = np.zeros((len(seq), self.reward_dim))
+                reward[:, -1] = fuel_costs[seq]
+                mine_actions = seq.count(ACT_MINE)
                 reward[-1, :-1] = mine_means * mine_actions / max(1, (mn_sum * mine_actions) / self.capacity)
 
-                reward = np.dot(discount_map[: len(s)], reward)
+                reward = np.dot(discount_map[:len(seq)], reward)
                 rewards_batch[idx] = reward
+                mine_pos_batch[idx] = tuple(mine.pos)
+                action_seq_batch[idx] = tuple(seq)
                 idx += 1
 
-                if idx >= batch_size:
+                if idx == batch_size:
                     pareto_mask = paretoset(rewards_batch, sense=["max"] * self.reward_dim)
-                    pareto_batches.append(rewards_batch[pareto_mask])
-                    rewards_batch = np.empty(shape=(batch_size, self.reward_dim))
+                    df = pd.DataFrame(rewards_batch[pareto_mask], columns=self.reward_names)
+                    df["Mine Position"] = mine_pos_batch[pareto_mask]
+                    df["Action Sequence"] = action_seq_batch[pareto_mask]
+                    pareto_batches.append(df)
                     idx = 0
 
-        pareto_batches.append(rewards_batch[:idx])
-        pareto_concat = np.concatenate(pareto_batches, axis=0)
-        pareto_mask = paretoset(pareto_concat, sense=["max"] * self.reward_dim)
-        pareto_rewards = pareto_concat[pareto_mask]
+        if idx > 0:
+            df = pd.DataFrame(rewards_batch[:idx], columns=self.reward_names)
+            df["Mine Position"] = mine_pos_batch[:idx]
+            df["Action Sequence"] = action_seq_batch[:idx]
+            pareto_batches.append(df)
 
-        return pareto_rewards
+        df_pareto = pd.concat(pareto_batches, axis=0)
+        pareto_mask = paretoset(df_pareto[self.reward_names].values, sense=["max"] * self.reward_dim)
+        df_pareto = df_pareto[pareto_mask]
+        df_pareto = df_pareto.reset_index(drop=True)
+
+        return df_pareto
 
     def generate_mines(self, mine_distributions=None):
         """

--- a/mo_gymnasium/envs/minecart/minecart.py
+++ b/mo_gymnasium/envs/minecart/minecart.py
@@ -15,7 +15,6 @@ from gymnasium.utils import EzPickle
 from paretoset import paretoset
 from scipy.spatial import ConvexHull
 
-
 EPS_SPEED = 0.001  # Minimum speed to be considered in motion
 HOME_X = 0.0
 HOME_Y = 0.0
@@ -171,7 +170,7 @@ class Minecart(gym.Env, EzPickle):
             )
             for i in range(self.ore_cnt)
         ]
-        self.reward_names = ["Ore" + str(i + 1) for i in range(self.ore_cnt)] + ["Fuel"]
+        self.reward_names = ["Ore_" + str(i + 1) for i in range(self.ore_cnt)] + ["Fuel"]
         self.generate_mines(None)
 
         if "mines" in data:
@@ -203,7 +202,9 @@ class Minecart(gym.Env, EzPickle):
         )
         self.reward_dim = self.ore_cnt + 1
 
-    def convex_coverage_set(self, gamma: float, symmetric: bool = True, batch_size: int = 10**5) -> pd.DataFrame:
+    def convex_coverage_set(
+        self, gamma: float, symmetric: bool = True, batch_size: int = 10**5
+    ) -> tuple[np.ndarray, pd.DataFrame]:
         """
         Computes an approximate convex coverage set (CCS).
 
@@ -213,28 +214,35 @@ class Minecart(gym.Env, EzPickle):
             batch_size (int): The number of trajectory rewards to store before computing a batch of pareto points. Default: 10**5
 
         Returns:
-            The convex coverage set
+            A tuple containing:
+                - convex_rewards (np.ndarray): Reward values ("Ore_1", ..., "Ore_n", "Fuel") of convex coverage set.
+                - df_convex (pd.DataFrame): Convex coverage set with rewards columns ("Ore_1", ..., "Ore_n", "Fuel"),
+                "Mine Position", and "Action Sequence".
         """
-        df_pareto = self.pareto_front(gamma, symmetric, batch_size)
-        pareto_rewards = df_pareto[self.reward_names].values
+        pareto_rewards, df_pareto = self.pareto_front(gamma, symmetric, batch_size)
         origin = np.min(pareto_rewards, axis=0)
         extended_rewards = np.concatenate([pareto_rewards, [origin]], axis=0)
         origin_idx = len(extended_rewards) - 1
         hull = ConvexHull(extended_rewards)
         vertices = hull.vertices[hull.vertices != origin_idx]
         df_convex = df_pareto.iloc[vertices]
-        return df_convex
+        convex_rewards = df_convex[self.reward_names].values
 
-    def pareto_front(self, gamma: float, symmetric: bool = True, batch_size: int = 10**5) -> pd.DataFrame:
+        return convex_rewards, df_convex
+
+    def pareto_front(self, gamma: float, symmetric: bool = True, batch_size: int = 10**5) -> tuple[np.ndarray, pd.DataFrame]:
         """
         Computes an approximate pareto front.
 
         Args:
-            gamma (float): Discount factor to apply to rewards
-            symmetric (bool): If true, we assume the pattern of accelerations from the base to the mine is the same as from the mine to the base. Default: True
+            gamma (float): Discount factor to apply to rewards symmetric (bool): If true, we assume the pattern of
+            accelerations from the base to the mine is the same as from the mine to the base. Default: True
             batch_size (int): The number of trajectory rewards to store before computing a batch of pareto points. Default: 10**5
         Returns:
-            The pareto coverage set
+            A tuple containing:
+                - pareto_rewards (np.ndarray): Reward values ("Ore_1", ..., "Ore_n", "Fuel") of pareto front.
+                - df_pareto (pd.DataFrame): Pareto front with reward columns ("Ore_1", ..., "Ore_n", "Fuel"),
+                "Mine Position", and "Action Sequence".
         """
         idx = 0
         rewards_batch = np.empty(shape=(batch_size, self.reward_dim), dtype=np.float64)
@@ -401,7 +409,7 @@ class Minecart(gym.Env, EzPickle):
                 mine_actions = seq.count(ACT_MINE)
                 reward[-1, :-1] = mine_means * mine_actions / max(1, (mn_sum * mine_actions) / self.capacity)
 
-                reward = np.dot(discount_map[:len(seq)], reward)
+                reward = np.dot(discount_map[: len(seq)], reward)
                 rewards_batch[idx] = reward
                 mine_pos_batch[idx] = tuple(mine.pos)
                 action_seq_batch[idx] = tuple(seq)
@@ -425,8 +433,9 @@ class Minecart(gym.Env, EzPickle):
         pareto_mask = paretoset(df_pareto[self.reward_names].values, sense=["max"] * self.reward_dim)
         df_pareto = df_pareto[pareto_mask]
         df_pareto = df_pareto.reset_index(drop=True)
+        pareto_rewards = df_pareto[self.reward_names].values
 
-        return df_pareto
+        return pareto_rewards, df_pareto
 
     def generate_mines(self, mine_distributions=None):
         """

--- a/mo_gymnasium/envs/minecart/minecart.py
+++ b/mo_gymnasium/envs/minecart/minecart.py
@@ -201,7 +201,7 @@ class Minecart(gym.Env, EzPickle):
         )
         self.reward_dim = self.ore_cnt + 1
 
-    def convex_coverage_set(self, gamma: float, symmetric: bool = True, batch_size: int = 10**5) -> List[np.ndarray]:
+    def convex_coverage_set(self, gamma: float, symmetric: bool = True, batch_size: int = 10**5) -> np.ndarray:
         """
         Computes an approximate convex coverage set (CCS).
 
@@ -215,10 +215,13 @@ class Minecart(gym.Env, EzPickle):
         """
         policies = self.pareto_front(gamma, symmetric, batch_size)
         origin = np.min(policies, axis=0)
-        extended_policies = [origin] + policies
-        return [policies[idx - 1] for idx in ConvexHull(extended_policies).vertices if idx != 0]
+        extended_policies = np.concatenate([[origin], policies], axis=0)
+        hull = ConvexHull(extended_policies)
+        vertices = hull.vertices[hull.vertices != 0]
+        convex_policies = hull.points[vertices]
+        return convex_policies
 
-    def pareto_front(self, gamma: float, symmetric: bool = True, batch_size: int = 10**5) -> List[np.ndarray]:
+    def pareto_front(self, gamma: float, symmetric: bool = True, batch_size: int = 10**5) -> np.ndarray:
         """
         Computes an approximate pareto front.
 
@@ -405,7 +408,7 @@ class Minecart(gym.Env, EzPickle):
         pareto_batches.append(rewards_batch[:idx])
         pareto_concat = np.concatenate(pareto_batches, axis=0)
         pareto_mask = paretoset(pareto_concat, sense=["max"] * self.reward_dim)
-        pareto_rewards = list(pareto_concat[pareto_mask])
+        pareto_rewards = pareto_concat[pareto_mask]
 
         return pareto_rewards
 

--- a/mo_gymnasium/envs/minecart/minecart.py
+++ b/mo_gymnasium/envs/minecart/minecart.py
@@ -4,7 +4,7 @@ import math
 import warnings
 from math import ceil
 from pathlib import Path
-from typing import List, Literal, Optional
+from typing import Literal, Optional
 
 import gymnasium as gym
 import numpy as np

--- a/mo_gymnasium/envs/minecart/minecart.py
+++ b/mo_gymnasium/envs/minecart/minecart.py
@@ -16,7 +16,6 @@ from gymnasium.utils import EzPickle
 from paretoset import paretoset
 from scipy.optimize import linprog
 
-
 EPS_SPEED = 0.001  # Minimum speed to be considered in motion
 HOME_X = 0.0
 HOME_Y = 0.0
@@ -253,7 +252,7 @@ class Minecart(gym.Env, EzPickle):
         )
         df_convex = df_pareto
         df_convex["Coplanar_Maximizable"] = coplanar_mask
-        df_convex["Stricly_Maximizable"] = strict_mask
+        df_convex["Strictly_Maximizable"] = strict_mask
         df_convex[self.weight_names] = weights
         df_convex["Margin"] = margins
 

--- a/mo_gymnasium/envs/minecart/minecart.py
+++ b/mo_gymnasium/envs/minecart/minecart.py
@@ -1,9 +1,10 @@
 import itertools
 import json
 import math
+import warnings
 from math import ceil
 from pathlib import Path
-from typing import List, Optional
+from typing import List, Literal, Optional
 
 import gymnasium as gym
 import numpy as np
@@ -13,7 +14,7 @@ import scipy.stats
 from gymnasium.spaces import Box, Discrete
 from gymnasium.utils import EzPickle
 from paretoset import paretoset
-from scipy.spatial import ConvexHull
+from scipy.optimize import linprog
 
 EPS_SPEED = 0.001  # Minimum speed to be considered in motion
 HOME_X = 0.0
@@ -171,6 +172,7 @@ class Minecart(gym.Env, EzPickle):
             for i in range(self.ore_cnt)
         ]
         self.reward_names = ["Ore_" + str(i + 1) for i in range(self.ore_cnt)] + ["Fuel"]
+        self.weight_names = [f"Weight_{reward_name}" for reward_name in self.reward_names]
         self.generate_mines(None)
 
         if "mines" in data:
@@ -203,30 +205,63 @@ class Minecart(gym.Env, EzPickle):
         self.reward_dim = self.ore_cnt + 1
 
     def convex_coverage_set(
-        self, gamma: float, symmetric: bool = True, batch_size: int = 10**5
+        self,
+        gamma: float,
+        symmetric: bool = True,
+        batch_size: int = 10**5,
+        include_coplanar: bool = True,
+        threshold: float = 0.0,
+        on_error: Literal["warn", "raise", "ignore"] = "warn",
     ) -> tuple[np.ndarray, pd.DataFrame]:
         """
-        Computes an approximate convex coverage set (CCS).
+        Computes an approximate convex coverage set (CCS) by determining which reward vectors are linearly maximizable.
+
+        A point p_i is linearly maximizable if there exists a weight vector v (non-negative, summing to 1) such that
+        p_i @ v >= p_j @ v for all j != i. Equivalently, if margin is the maximum value that satisfies
+        (p_i @ v) - (p_j @ v) >= margin for all j != i then
+        margin > 0 implies p_i is strictly maximizable (i.e. there exists v such that p_i is uniquely maximal),
+        margin == 0 implies p_i is coplanar maximizable (i.e. when p_i is maximal it ties with at least one p_j),
+        and margin < 0 implies p_i is not linearly maximizable (i.e. there is no v for which p_i is maximal).
 
         Args:
-            gamma (float): Discount factor to apply to rewards.
-            symmetric (bool): If true, we assume the pattern of accelerations from the base to the mine is the same as from the mine to the base. Default: True
-            batch_size (int): The number of trajectory rewards to store before computing a batch of pareto points. Default: 10**5
+            gamma: Discount factor to apply to rewards.
+            symmetric: If True, we assume the pattern of accelerations from the base to the mine is the same as from
+                the mine to the base. Default: True
+            batch_size: The number of trajectory rewards to store before computing a batch of pareto points.
+                Default: 10**5
+            include_coplanar: If True, points that tie for maximality are included (margin >= 0). If False, only points that
+                are uniquely maximal are included (margin > threshold).
+            threshold: minimum margin threshold for strict maximizability. Default: 0.0
+            on_error: Action to take if linprog fails to find a solution (status != 0). Default: "warn"
+                "warn"   - issue a warning and leave the corresponding weights and margin as NaN.
+                "raise"  - raise a RuntimeError.
+                "ignore" - silently leave the corresponding weights and margin as NaN.
 
         Returns:
             A tuple containing:
                 - convex_rewards (np.ndarray): Reward values ("Ore_1", ..., "Ore_n", "Fuel") of convex coverage set.
                 - df_convex (pd.DataFrame): Convex coverage set with rewards columns ("Ore_1", ..., "Ore_n", "Fuel"),
-                "Mine Position", and "Action Sequence".
+                "Mine_Position", "Action_Sequence", weight columns ("Weight_Ore_1", ..., "Weight_Ore_n", "Weight_Fuel"),
+                and "Margin". Weight columns correspond to the components of the weight vector v that maximizes the margin
+                for each point. "Margin" column contains the maximum achievable margin for each point.
         """
         pareto_rewards, df_pareto = self.pareto_front(gamma, symmetric, batch_size)
-        origin = np.min(pareto_rewards, axis=0)
-        extended_rewards = np.concatenate([pareto_rewards, [origin]], axis=0)
-        origin_idx = len(extended_rewards) - 1
-        hull = ConvexHull(extended_rewards)
-        vertices = hull.vertices[hull.vertices != origin_idx]
-        df_convex = df_pareto.iloc[vertices]
-        convex_rewards = df_convex[self.reward_names].values
+        coplanar_mask, strict_mask, weights, margins = check_linear_maximizability(
+            points=pareto_rewards,
+            threshold=threshold,
+            on_error=on_error,
+        )
+        df_convex = df_pareto
+        df_convex["Coplanar_Maximizable"] = coplanar_mask
+        df_convex["Stricly_Maximizable"] = strict_mask
+        df_convex[self.weight_names] = weights
+        df_convex["Margin"] = margins
+
+        if include_coplanar:
+            mask = coplanar_mask
+        else:
+            mask = strict_mask
+        convex_rewards = df_convex.loc[mask, self.reward_names].values
 
         return convex_rewards, df_convex
 
@@ -242,7 +277,7 @@ class Minecart(gym.Env, EzPickle):
             A tuple containing:
                 - pareto_rewards (np.ndarray): Reward values ("Ore_1", ..., "Ore_n", "Fuel") of pareto front.
                 - df_pareto (pd.DataFrame): Pareto front with reward columns ("Ore_1", ..., "Ore_n", "Fuel"),
-                "Mine Position", and "Action Sequence".
+                "Mine_Position", and "Action_Sequence".
         """
         idx = 0
         rewards_batch = np.empty(shape=(batch_size, self.reward_dim), dtype=np.float64)
@@ -352,11 +387,6 @@ class Minecart(gym.Env, EzPickle):
                     )
             else:
                 if not symmetric:
-                    print(
-                        [ACT_NONE] + trimmed_sequences[1:],
-                        trimmed_sequences[1:],
-                        trimmed_sequences,
-                    )
                     all_sequences = map(
                         lambda sequences: list(sequences[0])
                         + list(sequences[1])
@@ -418,15 +448,15 @@ class Minecart(gym.Env, EzPickle):
                 if idx == batch_size:
                     pareto_mask = paretoset(rewards_batch, sense=["max"] * self.reward_dim)
                     df = pd.DataFrame(rewards_batch[pareto_mask], columns=self.reward_names)
-                    df["Mine Position"] = mine_pos_batch[pareto_mask]
-                    df["Action Sequence"] = action_seq_batch[pareto_mask]
+                    df["Mine_Position"] = mine_pos_batch[pareto_mask]
+                    df["Action_Sequence"] = action_seq_batch[pareto_mask]
                     pareto_batches.append(df)
                     idx = 0
 
         if idx > 0:
             df = pd.DataFrame(rewards_batch[:idx], columns=self.reward_names)
-            df["Mine Position"] = mine_pos_batch[:idx]
-            df["Action Sequence"] = action_seq_batch[:idx]
+            df["Mine_Position"] = mine_pos_batch[:idx]
+            df["Action_Sequence"] = action_seq_batch[:idx]
             pareto_batches.append(df)
 
         df_pareto = pd.concat(pareto_batches, axis=0)
@@ -868,6 +898,93 @@ def truncated_mean(mean, std, a, b):
 
     trunc_mean = mean + ((phia - phib) / (PHIB - PHIA)) * std
     return trunc_mean
+
+
+def check_linear_maximizability(
+    points: np.ndarray, threshold: float = 0.0, on_error: Literal["warn", "raise", "ignore"] = "warn"
+) -> tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
+    """
+    Determine which reward vectors are linearly maximizable.
+
+    A point p_i is linearly maximizable if there exists a weight vector v (non-negative, summing to 1) such that
+    p_i @ v >= p_j @ v for all j != i. Equivalently, if margin is the maximum value that satisfies
+    (p_i @ v) - (p_j @ v) >= margin for all j != i then
+    margin > 0 implies p_i is strictly maximizable (i.e. there exists v such that p_i is uniquely maximal),
+    margin == 0 implies p_i is coplanar maximizable (i.e. when p_i is maximal it ties with at least one p_j),
+    and margin < 0 implies p_i is not linearly maximizable (i.e. there is no v for which p_i is maximal).
+
+    Args:
+        points: (n, dim) array of reward vectors.
+        threshold: minimum margin threshold for strict maximizability. Default: 0.0
+        on_error: Action to take if linprog fails to find a solution (status != 0). Default: "warn"
+            "warn"   - issue a warning and leave the corresponding weights and margin as NaN.
+            "raise"  - raise a RuntimeError.
+            "ignore" - silently leave the corresponding weights and margin as NaN.
+
+    Returns:
+        coplanar_mask: (n,) bool array - True where point is coplanar maximizable.
+        strict_mask: (n,) bool array - True where point is strictly maximizable.
+        weights: (n, dim) float array - weight vectors v that maximize the margin for each point.
+        margins: (n,) float array - maximum achievable margin for each point.
+    """
+    if on_error not in ("warn", "raise", "ignore"):
+        raise ValueError(f"on_error must be 'warn', 'raise', or 'ignore', got {on_error!r}")
+
+    points = np.atleast_2d(points)
+    n, dim = points.shape
+
+    weights = np.full((n, dim), np.nan)
+    margins = np.full(n, np.nan)
+
+    # v = [w_1, w_2, ..., w_dim]
+    # x = [w_1, w_2, ..., w_dim, margin]
+    # linprog minimizes c @ x
+    # Maximize margin, i.e. minimize -margin
+    # c = [0, ..., 0, -1]
+    c = np.zeros(dim + 1)
+    c[-1] = -1.0
+
+    # Constrain sum(v) == 1 to fix the scale of v.
+    # Without this, if x = [v_0, m_0] is feasible (i.e. satisfies A_ub @ x <= 0) then [k*v_0, k*m_0] is feasible
+    # for any k >= 0. If p_i is strictly maximizable then m_0 > 0, so maximizing k*m_0 gives k -> inf (unbounded).
+    # If p_i is non-maximizable then m_0 < 0, so maximizing k*m_0 gives k = 0, incorrectly reporting margin = 0
+    # and causing p_i to register as coplanar maximizable.
+    A_eq = np.zeros((1, dim + 1))
+    A_eq[0, :dim] = 1.0
+    b_eq = np.array([1.0])
+
+    # Weights must be non-negative. margin unconstrained
+    bounds = [(0, None)] * dim + [(None, None)]
+
+    for i in range(n):
+        # linprog constrains A_ub @ x <= b_ub
+        # so inequality must be rearranged into this form
+        # (p_i @ v) - (p_j @ v) >= margin
+        # (p_i - p_j) @ v >= margin
+        # (p_j - p_i) @ v <= -margin
+        # (p_j - p_i) @ v + margin <= 0
+        # [diff, 1] @ [v, margin] <= 0
+        j_mask = np.arange(n) != i
+        diff = points[j_mask] - points[i]  # (n-1, dim)
+        A_ub = np.hstack([diff, np.ones((n - 1, 1))])  # (n-1, dim+1)
+        b_ub = np.zeros(n - 1)
+
+        res = linprog(c=c, A_ub=A_ub, b_ub=b_ub, A_eq=A_eq, b_eq=b_eq, bounds=bounds)
+
+        if res.status == 0:
+            weights[i] = res.x[:-1]
+            margins[i] = res.x[-1]
+        elif on_error == "warn":
+            warnings.warn(f"Linprog status={res.status} for points[{i}] = {points[i]}.")
+        elif on_error == "raise":
+            raise RuntimeError(f"Linprog status={res.status} for points[{i}] = {points[i]}.")
+        elif on_error == "ignore":
+            pass
+
+    coplanar_mask = margins >= 0
+    strict_mask = margins > threshold
+
+    return coplanar_mask, strict_mask, weights, margins
 
 
 if __name__ == "__main__":

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ dynamic = ["version"]
 [project.optional-dependencies]
 # Update dependencies in `all` if any are added or removed
 mario = ["nes-py", "gym-super-mario-bros", "numpy >=1.21.0,<2.0"]
-minecart = ["scipy >=1.7.3  "]
+minecart = ["scipy >=1.7.3", "paretoset"]
 mujoco = ["mujoco >=2.2.0", "imageio >=2.14.1"]
 highway = ["highway-env >=1.8"]
 box2d = ["box2d-py ==2.3.5", "pygame >=2.1.3", "swig ==4.*"]
@@ -44,6 +44,7 @@ all = [
     "gym-super-mario-bros",
     # minecart
     "scipy >=1.7.3",
+    "paretoset",
     # mujoco
     "imageio >=2.14.1",
     "mujoco >=2.2.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ dynamic = ["version"]
 [project.optional-dependencies]
 # Update dependencies in `all` if any are added or removed
 mario = ["nes-py", "gym-super-mario-bros", "numpy >=1.21.0,<2.0"]
-minecart = ["scipy >=1.7.3", "paretoset"]
+minecart = ["scipy >=1.7.3", "paretoset", "pandas"]
 mujoco = ["mujoco >=2.2.0", "imageio >=2.14.1"]
 highway = ["highway-env >=1.8"]
 box2d = ["box2d-py ==2.3.5", "pygame >=2.1.3", "swig ==4.*"]
@@ -45,6 +45,7 @@ all = [
     # minecart
     "scipy >=1.7.3",
     "paretoset",
+    "pandas",
     # mujoco
     "imageio >=2.14.1",
     "mujoco >=2.2.0",


### PR DESCRIPTION
The Convex Coverage Set (CCS) can be calculated correctly using `scipy.optimize.linprog`, replacing the algorithm which misapplied `scipy.spatial.ConvexHull`.

`check_linear_maximizability` determines which reward vectors are linearly maximizable (i.e. there exists a linear objective function with non-negative coefficients for which that reward vector is optimal). `Minecart.convex_coverage_set` applies `check_linear_maximizability` to Minecart's pareto front to calculate the CCS.

In addition to fixing `Minecart.convex_coverage_set`, this PR includes several other improvements:

- **batch_size parameter for `Minecart.pareto_front`** - When frame_skip = 1 the number of policies evaluated is very large, and storing all of the associated episode rewards in a list can cause excessive memory usage. Accumulating the rewards into batches that can be pareto filtered and then discarded reduces memory usage.
- **external `paretoset` library** - The custom `pareto_filter` function is slow, especially on large lists. Using the external `paretoset` library speeds up computation, which is particularly relevant when frame_skip <= 2 since takes a significant amount of time.
- **pre-allocating arrays** - Rather than appending rewards to a list they are stored in a pre-allocated array (which is re-used for each batch). This improves computation time very slightly, but not enough to make this particularly noteworthy.
- **return pandas DataFrame** - `pareto_front` and `convex_coverage_set` return a `tuple[np.ndarray, pd.DataFrame]` rather than `List[np.ndarray]`. This is a **breaking change** so I have bumped the Minecart version from v0 to v1 (though it doesn't affect the learning algorithm so perhaps a version bump is unnecessary?). The DataFrame allows additional information to be returned about each point on the pareto front, such as which mine location the policy navigates to, and the sequence of actions the policy executed. `pareto_front` uses heuristics to calculate policies, rather than fully simulating the environment, so having access to the sequence of actions for each policy makes it possible for users to compare the heuristic reward to the true reward that would be achieved in the environment. (This comparison is not implemented in this PR, only the action sequence is provided.) Unfortunately, creating the DataFrame causes a significant increase in computation time (though the computation time is still less than before this PR since computation time was saved using `paretoset` rather than `pareto_filter`). If the additional computation time is a concern I could add a flag that determines whether to compute the DataFrame. Returning the np.ndarray is redundant because all of the information is already present in the DataFrame, but the array provides more convenient access for users who only want the rewards.
- **`convex_coverage_set` can include/exclude coplanar maximizable points** - Points that only tie for maximality (never uniquely maximal) can be included or excluded from the CCS np.ndarray. The DataFrame provides a column for both coplanar maximizable and strictly maximizable points, along with the weight vector that maximizes the margin of each point, as well as a column for the maximum margin. The weights are useful if a user wants to independently verify that a particular point is truly part of the CCS. The margin is useful if a user wants to inspect how closely a policy exceeds the performance of the next best policy.

@LucasAlegre @ffelten, are you comfortable with me lumping all of these changes together into a single PR, or would you like me to strip back this PR to solely fixing the CCS issue? Would you like me to submit separate PRs for each of the other improvements? Would you like me to include data regarding the computation time comparisons for each of the changes described?