### PR TITLE
Avoid full pygame.init() when rendering for faster startup

### DIFF
--- a/mo_gymnasium/envs/breakable_bottles/breakable_bottles.py
+++ b/mo_gymnasium/envs/breakable_bottles/breakable_bottles.py
@@ -245,7 +245,7 @@ class BreakableBottles(Env, EzPickle):
             return
 
         if self.window is None:
-            pygame.init()
+            pygame.font.init()
 
             if self.render_mode == "human":
                 pygame.display.init()

--- a/mo_gymnasium/envs/deep_sea_treasure/deep_sea_treasure.py
+++ b/mo_gymnasium/envs/deep_sea_treasure/deep_sea_treasure.py
@@ -234,7 +234,7 @@ class DeepSeaTreasure(gym.Env, EzPickle):
             return
 
         if self.window is None:
-            pygame.init()
+            pygame.font.init()
 
             if self.render_mode == "human":
                 pygame.display.init()

--- a/mo_gymnasium/envs/four_room/four_room.py
+++ b/mo_gymnasium/envs/four_room/four_room.py
@@ -237,7 +237,6 @@ class FourRoom(gym.Env, EzPickle):
         pix_square_size = self.window_size // 13
 
         if self.window is None and self.render_mode is not None:
-            pygame.init()
             if self.render_mode == "human":
                 pygame.display.init()
                 self.window = pygame.display.set_mode((self.window_size, self.window_size))

--- a/mo_gymnasium/envs/fruit_tree/fruit_tree.py
+++ b/mo_gymnasium/envs/fruit_tree/fruit_tree.py
@@ -378,7 +378,7 @@ class FruitTreeEnv(gym.Env, EzPickle):
             self.clock = pygame.time.Clock()
 
         if self.window is None:
-            pygame.init()
+            pygame.font.init()
 
             if self.render_mode == "human":
                 pygame.display.init()

--- a/mo_gymnasium/envs/minecart/minecart.py
+++ b/mo_gymnasium/envs/minecart/minecart.py
@@ -604,7 +604,6 @@ class Minecart(gym.Env, EzPickle):
     def render(self):
         if self.canvas is None or self.last_render_mode_used != self.render_mode:
             self.last_render_mode_used = self.render_mode
-            pygame.init()
             self.canvas = pygame.Surface((WIDTH, HEIGHT))
             if self.render_mode == "human":
                 pygame.display.init()

--- a/mo_gymnasium/envs/resource_gathering/resource_gathering.py
+++ b/mo_gymnasium/envs/resource_gathering/resource_gathering.py
@@ -180,8 +180,6 @@ class ResourceGathering(gym.Env, EzPickle):
             return
 
         if self.window is None:
-            pygame.init()
-
             if self.render_mode == "human":
                 pygame.display.init()
                 pygame.display.set_caption("Resource Gathering")

--- a/mo_gymnasium/envs/water_reservoir/dam_env.py
+++ b/mo_gymnasium/envs/water_reservoir/dam_env.py
@@ -169,7 +169,7 @@ class DamEnv(gym.Env, EzPickle):
 
     def _render_gui(self, render_mode: str):
         if self.window is None:
-            pygame.init()
+            pygame.font.init()
 
             if render_mode == "human":
                 pygame.display.init()


### PR DESCRIPTION
## Description

Per Farama-Foundation/MO-Gymnasium#126 (which references the PettingZoo discussion in Farama-Foundation/PettingZoo#1252 and the fix in PettingZoo#1343).

`pygame.init()` initializes **every** pygame subsystem — including audio and joystick device enumeration — which can take several seconds on some platforms. Rendering only needs the font module (for envs that draw text) and the display module (only in `human` mode, which is already initialized conditionally via `pygame.display.init()`).

This PR removes the blanket `pygame.init()` from each env's render path:

- **Text-drawing envs** (`deep_sea_treasure`, `water_reservoir`, `breakable_bottles`, `fruit_tree`): `pygame.init()` → `pygame.font.init()`.
- **Envs without text** (`resource_gathering`, `minecart`): `pygame.init()` removed; surface/image/transform/sprite calls don't require it.
- **`four_room`**: `pygame.init()` removed — it already calls `pygame.font.init()` separately in the render path.

The conditional `pygame.display.init()` for `render_mode == "human"` is unchanged.

## Verification

Smoke-tested all seven affected envs in `rgb_array` mode (headless, `SDL_VIDEODRIVER=dummy`); each resets and renders a valid frame:

```
deep-sea-treasure-v0     -> OK shape=(512, 532, 3)
water-reservoir-v0       -> OK shape=(200, 300, 3)
breakable-bottles-v0     -> OK shape=(64, 320, 3)
fruit-tree-v0            -> OK shape=(270, 1200, 3)
four-room-v0             -> OK shape=(455, 455, 3)
resource-gathering-v0    -> OK shape=(320, 320, 3)
minecart-v0              -> OK shape=(480, 480, 3)
```

Closes #126

🤖 Generated with [Claude Code](https://claude.com/claude-code)