### PR TITLE
Docs: show a screenshot for envs without rgb_array rendering (fixes missing fishwood figure)

### DIFF
--- a/docs/_scripts/gen_env_docs.py
+++ b/docs/_scripts/gen_env_docs.py
@@ -135,9 +135,17 @@ title: {title_env_name}
 {related_pages_meta}---
 """
         title = f"# {title_env_name}"
+        screenshot_path = os.path.join(os.path.dirname(__file__), "..", "_static", "screenshots", f"{snake_env_name}.png")
         if "rgb_array" in env.metadata["render_modes"]:
             gif = (
                 "```{figure}" + f" ../_static/videos/{snake_env_name}.gif" + f" \n:width: 200px\n:name: {snake_env_name}\n```"
+            )
+        elif os.path.exists(screenshot_path):
+            # envs without graphical rendering (e.g. fishwood) fall back to a checked-in screenshot
+            gif = (
+                "```{figure}"
+                + f" ../_static/screenshots/{snake_env_name}.png"
+                + f" \n:width: 200px\n:name: {snake_env_name}\n```"
             )
         else:
             gif = ""


### PR DESCRIPTION
## Problem

https://mo-gymnasium.farama.org/environments/fishwood/ shows no environment figure. The per-env pages are generated by `docs/_scripts/gen_env_docs.py`, which only emits a figure when the env supports `rgb_array` rendering (embedding `_static/videos/<env>.gif`). `fishwood-v0` only declares `render_modes: ["human"]` (its render is a text string), so no gif exists and the page gets no image — even though `docs/_static/screenshots/fishwood.png` is checked in and already used for fishwood's entry in the grid-world overview table. A scan of all 25 env pages on the live site shows fishwood is the only page affected.

## Change

When an env lacks `rgb_array` but `docs/_static/screenshots/<env>.png` exists, embed the screenshot instead of emitting nothing. Envs with `rgb_array` are unaffected, and any future text-only env with a checked-in screenshot gets a figure automatically.

## Verification

Built the docs locally with this change: `docs/environments/fishwood.md` now contains the figure block, and the built page renders `<img src="../../_images/fishwood.png" style="width: 200px;">` — the same markup shape as the gif-based env pages. `deep-sea-treasure` (rgb_array path) was checked as a control and is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)