### PR TITLE
Fix tests badge showing failing while main is passing

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 [![Python](https://img.shields.io/pypi/pyversions/mo-gymnasium.svg)](https://badge.fury.io/py/mo-gymnasium)
 [![PyPI](https://badge.fury.io/py/mo-gymnasium.svg)](https://badge.fury.io/py/mo-gymnasium)
-![tests](https://github.com/Farama-Foundation/mo-gymnasium/workflows/Python%20tests/badge.svg)
+[![tests](https://github.com/Farama-Foundation/MO-Gymnasium/actions/workflows/test.yml/badge.svg?branch=main&event=push)](https://github.com/Farama-Foundation/MO-Gymnasium/actions/workflows/test.yml)
 [![pre-commit](https://img.shields.io/badge/pre--commit-enabled-brightgreen?logo=pre-commit&logoColor=white)](https://pre-commit.com/)
 [![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)
 


### PR DESCRIPTION
The README used GitHub's legacy badge URL format (workflows/Python%20tests/badge.svg), which is not scoped to any branch or event. It shows the status of the most recent run of the workflow across all branches and event types. Since test.yml triggers on both push and pull_request, a failing run on any PR (the matrix goes up to Python 3.14) turns the badge red even while push runs on main are green.
This migrates the badge to the modern workflow-file format, scoped to main and push events:
actions/workflows/test.yml/badge.svg?branch=main&event=push
The badge is also now a link to the workflow's runs page, consistent with the other badges in the README (it was previously the only non-clickable one).
Same issue was diagnosed and confirmed in niklasf/python-chess#1196.