### PR TITLE
Reset discounted episode returns between episodes in vectorized MORecordEpisodeStatistics

### DIFF
--- a/mo_gymnasium/wrappers/vector/wrappers.py
+++ b/mo_gymnasium/wrappers/vector/wrappers.py
@@ -400,10 +400,10 @@ class MORecordEpisodeStatistics(RecordEpisodeStatistics):
         """
         gym.utils.RecordConstructorArgs.__init__(self, buffer_length=buffer_length, stats_key=stats_key)
         RecordEpisodeStatistics.__init__(self, env, buffer_length=buffer_length, stats_key=stats_key)
-        self.disc_episode_returns = None
         self.reward_dim = self.env.unwrapped.reward_space.shape[0]
         self.rewards_shape = (self.num_envs, self.reward_dim)
         self.gamma = gamma
+        self.disc_episode_returns = np.zeros(self.rewards_shape, dtype=np.float32)
 
     def reset(self, **kwargs):
         """Resets the environment using kwargs and resets the episode returns and lengths."""
@@ -430,6 +430,7 @@ class MORecordEpisodeStatistics(RecordEpisodeStatistics):
         ), f"`vector.RecordEpisodeStatistics` requires `info` type to be `dict`, its actual type is {type(infos)}. This may be due to usage of other wrappers in the wrong order."
 
         self.episode_returns[self.prev_dones] = 0
+        self.disc_episode_returns[self.prev_dones] = 0
         self.episode_lengths[self.prev_dones] = 0
         self.episode_start_times[self.prev_dones] = time.perf_counter()
         self.episode_returns[~self.prev_dones] += rewards[~self.prev_dones]

--- a/tests/test_vector_wrappers.py
+++ b/tests/test_vector_wrappers.py
@@ -111,6 +111,29 @@ def test_mo_record_ep_statistic_vector_env_async():
     envs.close()
 
 
+def test_mo_record_ep_statistic_disc_return_reset_between_episodes():
+    # Regression: disc_episode_returns must be zeroed for autoreset sub-envs so a new
+    # episode's discounted return is not polluted by the previous episode's.
+    envs = MOSyncVectorEnv([lambda: mo_gym.make("deep-sea-treasure-v0")])
+    envs = MORecordEpisodeStatistics(envs, gamma=0.97)
+    envs.reset()
+    # Episode 1: reach the (8.2, -3) treasure in 3 steps (same trajectory as go_to_8_3)
+    envs.step([3])
+    envs.step([1])
+    _, _, terminateds, _, info = envs.step([1])
+    assert terminateds[0]
+    np.testing.assert_allclose(info["episode"]["dr"][0], [7.71538, -2.9109], rtol=0, atol=1e-2)
+    # Autoreset step (reward is 0 for the reset sub-env)
+    envs.step([0])
+    # Episode 2: identical trajectory must yield the identical discounted return
+    envs.step([3])
+    envs.step([1])
+    _, _, terminateds, _, info = envs.step([1])
+    assert terminateds[0]
+    np.testing.assert_allclose(info["episode"]["dr"][0], [7.71538, -2.9109], rtol=0, atol=1e-2)
+    envs.close()
+
+
 def _test_gym_wrapper_and_vector_logic(envs, num_envs: int):
     envs.reset()
     for i in range(30):


### PR DESCRIPTION
## What

In the vectorized `MORecordEpisodeStatistics.step` (`mo_gymnasium/wrappers/vector/wrappers.py`), zero `self.disc_episode_returns` for finished sub-envs alongside the existing reset of `episode_returns`, `episode_lengths`, and `episode_start_times`.

## Why

The per-episode accumulators for finished sub-envs are cleared for `episode_returns`, `episode_lengths`, and `episode_start_times`, but `disc_episode_returns` was never cleared during `step` — it is only zeroed once in `reset()`. Because vectorized sub-envs autoreset (they never call the wrapper's `reset()`), the discounted-return accumulator leaked across episode boundaries. As a result, the `dr` reported in `info["episode"]` for the 2nd (and every subsequent) episode of a given sub-env was that episode's discounted return plus all prior episodes' discounted returns. The undiscounted `r` was already correct because it is reset.

No masking is needed on the subsequent `disc_episode_returns += rewards * gamma**episode_lengths` update: on the autoreset step both `MOSyncVectorEnv` and `MOAsyncVectorEnv` return `reward = 0` for the reset sub-env, so the zeroed accumulator stays 0.

## Testing

Added `test_mo_record_ep_statistic_disc_return_reset_between_episodes` in `tests/test_vector_wrappers.py`. It runs two identical episodes in a single-env `MOSyncVectorEnv` wrapped with `MORecordEpisodeStatistics(gamma=0.97)` on `deep-sea-treasure-v0` and asserts the discounted return of the second episode equals the first (`[7.71538, -2.9109]`). Before the fix the second episode reports roughly double (`~[15.43, -5.82]`) and the test fails; after the fix it passes. The existing single-episode vector tests are unaffected (on the terminal step `prev_dones` is all-False, so the new line is a no-op for them).

Run: `pytest tests/test_vector_wrappers.py -q` -> 9 passed.
