### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build-publish.yml
+++ b/.github/workflows/build-publish.yml
@@ -14,6 +14,9 @@ on:
   release:
     types: [published]
 
+permissions:
+  contents: read
+
 jobs:
   build-wheels:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/Farama-Foundation/MO-Gymnasium/security/code-scanning/1](https://github.com/Farama-Foundation/MO-Gymnasium/security/code-scanning/1)

Add an explicit `permissions` block to the workflow root in `.github/workflows/build-publish.yml`, immediately after the `on:` triggers (or before `jobs:`), with least-privilege values required for these jobs.

Best single fix without changing functionality:
- Set:
  - `contents: read` (needed by `actions/checkout`)
- Keep this at the workflow root so both jobs inherit it consistently.
- No additional imports, methods, or dependencies are needed.

This preserves behavior while making token scope explicit and restricted.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
