### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ main ]
 
+permissions:
+  contents: read
+
 jobs:
   linux-test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/Farama-Foundation/MO-Gymnasium/security/code-scanning/3](https://github.com/Farama-Foundation/MO-Gymnasium/security/code-scanning/3)

Add an explicit top-level `permissions` block in `.github/workflows/test.yml` so all jobs inherit minimal token scope.  
Best fix without changing functionality: set:

- `permissions:`
  - `contents: read`

This is sufficient for `actions/checkout` and test execution in the shown workflow. Place it near the top of the file (after `on:` block or after `name:`) so it applies globally to current and future jobs unless overridden.

No imports, methods, or external definitions are needed (YAML config-only change).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
