### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build-publish.yml
+++ b/.github/workflows/build-publish.yml
@@ -14,6 +14,10 @@ on:
   release:
     types: [published]
 
+permissions:
+  contents: read
+  packages: read
+
 jobs:
   build-wheels:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/Farama-Foundation/MO-Gymnasium/security/code-scanning/2](https://github.com/Farama-Foundation/MO-Gymnasium/security/code-scanning/2)

Add explicit `permissions` so the workflow does not inherit potentially over-privileged defaults.

Best single fix here: add a **workflow-level** `permissions` block near the top (after `on:` triggers, before `jobs:`), granting only what these jobs need:
- `contents: read` (needed for checkout/repository read access)
- `packages: read` (safe minimal read for package-related operations; commonly recommended baseline)

This keeps behavior unchanged while documenting and enforcing least privilege across both jobs.

File to edit:
- `.github/workflows/build-publish.yml`  
Region:
- Insert `permissions:` block between the event triggers and `jobs:`.

No imports, methods, or dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
