### PR TITLE
Validate the arguments of MONormalizeReward and MOClipReward

### DIFF
--- a/mo_gymnasium/wrappers/wrappers.py
+++ b/mo_gymnasium/wrappers/wrappers.py
@@ -14,6 +14,28 @@ ObsType = TypeVar("ObsType")
 ActType = TypeVar("ActType")
 
 
+def _check_reward_index(env: gym.Env, idx: int) -> None:
+    """Raise if `idx` does not address a component of the environment's reward vector.
+
+    Negative indices keep their usual meaning; only values that would raise an
+    `IndexError` on the first step are rejected, and they are rejected here so the
+    message names the parameter instead of surfacing later from inside `numpy`.
+
+    Args:
+        env: the environment being wrapped
+        idx: the index of the reward component the wrapper acts on
+
+    Raises:
+        ValueError: If `idx` is outside the reward vector.
+    """
+    reward_space = getattr(env.unwrapped, "reward_space", None)
+    if reward_space is None or reward_space.shape is None or len(reward_space.shape) == 0:
+        return
+    size = int(reward_space.shape[0])
+    if not -size <= idx < size:
+        raise ValueError(f"`idx` should address one of the {size} reward components, actual value: {idx}")
+
+
 class LinearReward(gym.Wrapper, gym.utils.RecordConstructorArgs):
     """Makes the env return a scalar reward, which is the dot-product between the reward vector and the weight vector."""
 
@@ -80,9 +102,22 @@ class MONormalizeReward(gym.Wrapper, gym.utils.RecordConstructorArgs):
             idx (int): the index of the reward to normalize
             epsilon (float): A stability parameter
             gamma (float): The discount factor that is used in the exponential moving average.
+
+        Raises:
+            ValueError: If `idx` is outside the reward vector, if `gamma` is outside
+                [0, 1], or if `epsilon` is not strictly positive.
         """
         gym.utils.RecordConstructorArgs.__init__(self, idx=idx, gamma=gamma, epsilon=epsilon)
         gym.Wrapper.__init__(self, env)
+        _check_reward_index(env, idx)
+        # The accumulator is multiplied by `gamma` on every step, so a value above one
+        # makes it diverge instead of converging, and `epsilon` is added under a square
+        # root to keep the division away from zero, which a non-positive value cannot
+        # do. Both mirror the checks in Gymnasium's own `NormalizeReward`.
+        if not 0 <= gamma <= 1:
+            raise ValueError(f"`gamma` should be in the interval [0, 1], actual value: {gamma}")
+        if epsilon <= 0:
+            raise ValueError(f"`epsilon` should be strictly positive, actual value: {epsilon}")
         self.idx = idx
         self.return_rms = RunningMeanStd(shape=())
         self.discounted_reward: np.array = np.array([0.0])
@@ -134,9 +169,19 @@ class MOClipReward(gym.RewardWrapper, gym.utils.RecordConstructorArgs):
             idx: index of the MO reward to clip
             min_r: min reward
             max_r: max reward
+
+        Raises:
+            ValueError: If `idx` is outside the reward vector, or if `min_r` is
+                greater than `max_r`.
         """
         gym.utils.RecordConstructorArgs.__init__(self, idx=idx, min_r=min_r, max_r=max_r)
         gym.RewardWrapper.__init__(self, env)
+        _check_reward_index(env, idx)
+        # `np.clip` silently returns `max_r` for every reward when the bounds are
+        # crossed, so the component is pinned to a constant rather than clipped.
+        # Gymnasium's `ClipReward` rejects the same case.
+        if np.any(np.asarray(max_r) < np.asarray(min_r)):
+            raise ValueError(f"`min_r` should not be greater than `max_r`, actual values: {min_r}, {max_r}")
         self.idx = idx
         self.min_r = min_r
         self.max_r = max_r

--- a/tests/test_wrappers.py
+++ b/tests/test_wrappers.py
@@ -1,4 +1,5 @@
 import numpy as np
+import pytest
 
 import mo_gymnasium as mo_gym
 from mo_gymnasium.wrappers import (
@@ -70,6 +71,61 @@ def test_clip_wrapper():
     np.testing.assert_allclose(rewards, [0.5, -1.0], rtol=0, atol=1e-2)
     rewards, _ = go_to_8_3(clip_treasure_env)
     np.testing.assert_allclose(rewards, [0.5, -1.0], rtol=0, atol=1e-2)
+
+
+@pytest.mark.parametrize("idx", [2, 7, -3, -9])
+def test_reward_index_outside_the_reward_vector(idx):
+    """An index that cannot address a reward component is rejected on construction.
+
+    `deep-sea-treasure-v0` has two of them, so anything outside [-2, 1] used to be
+    accepted and then raised `IndexError` from inside numpy several steps later.
+    """
+    with pytest.raises(ValueError, match="reward components"):
+        MONormalizeReward(mo_gym.make("deep-sea-treasure-v0"), idx=idx)
+
+    with pytest.raises(ValueError, match="reward components"):
+        MOClipReward(mo_gym.make("deep-sea-treasure-v0"), idx=idx, min_r=0, max_r=1)
+
+
+@pytest.mark.parametrize("idx", [0, 1, -1, -2])
+def test_reward_index_inside_the_reward_vector(idx):
+    """Every valid index keeps working, negative ones included."""
+    env = MONormalizeReward(mo_gym.make("deep-sea-treasure-v0"), idx=idx)
+    env.reset(seed=0)
+    env.step(1)
+    env.close()
+
+
+@pytest.mark.parametrize("gamma", [-1.0, -0.01, 1.01, 2.0, 99])
+def test_normalize_reward_rejects_gamma_outside_unit_interval(gamma):
+    """The accumulator is multiplied by `gamma` every step, so it diverges outside [0, 1]."""
+    with pytest.raises(ValueError, match="interval"):
+        MONormalizeReward(mo_gym.make("deep-sea-treasure-v0"), idx=0, gamma=gamma)
+
+
+@pytest.mark.parametrize("gamma", [0.0, 0.5, 0.99, 1.0])
+def test_normalize_reward_accepts_gamma_in_unit_interval(gamma):
+    """Both endpoints are meaningful: 0 keeps only the immediate reward, 1 is undiscounted."""
+    env = MONormalizeReward(mo_gym.make("deep-sea-treasure-v0"), idx=0, gamma=gamma)
+    assert env.gamma == gamma
+    env.close()
+
+
+@pytest.mark.parametrize("epsilon", [0.0, -1e-8, -1.0])
+def test_normalize_reward_rejects_non_positive_epsilon(epsilon):
+    """`epsilon` sits under a square root to keep the division away from zero."""
+    with pytest.raises(ValueError, match="strictly positive"):
+        MONormalizeReward(mo_gym.make("deep-sea-treasure-v0"), idx=0, epsilon=epsilon)
+
+
+def test_clip_reward_rejects_crossed_bounds():
+    """`np.clip` with crossed bounds pins the component to `max_r` instead of clipping."""
+    with pytest.raises(ValueError, match="greater than"):
+        MOClipReward(mo_gym.make("deep-sea-treasure-v0"), idx=0, min_r=5.0, max_r=1.0)
+
+    # Equal bounds are a legitimate way to pin a component and stay accepted.
+    env = MOClipReward(mo_gym.make("deep-sea-treasure-v0"), idx=0, min_r=1.0, max_r=1.0)
+    env.close()
 
 
 def test_mo_record_ep_statistic():


### PR DESCRIPTION
## Summary

Neither `MONormalizeReward` nor `MOClipReward` checks its constructor arguments.

**`idx`** names the reward component the wrapper acts on, and was stored unchecked. On `deep-sea-treasure-v0`, which has two components:

```python
env = MONormalizeReward(mo_gym.make("deep-sea-treasure-v0"), idx=7)  # accepted
env.reset(seed=0)
env.step(1)
# IndexError: index 7 is out of bounds for axis 0 with size 2
```

The error arrives several steps later, from inside numpy, naming neither the wrapper nor the parameter.

**`gamma` and `epsilon`** are unchecked in `MONormalizeReward`. `gamma` multiplies the accumulator on every step, so a value above one makes it diverge instead of converging — `gamma=99`, a plausible typo for `0.99`, is accepted. `epsilon` is added under a square root to keep the division away from zero, which a non-positive value cannot do. The docstring says the wrapper is heavily inspired on Gymnasium's `NormalizeReward`, which rejects both since Farama-Foundation/Gymnasium#1669.

**`min_r > max_r`** is accepted by `MOClipReward`, where `np.clip` returns `max_r` for every reward: the component is pinned to a constant rather than clipped. Gymnasium's `ClipReward` rejects the same case with `InvalidBound`.

## Changes

* `mo_gymnasium/wrappers/wrappers.py`
  * a shared `_check_reward_index` helper, reading `reward_space` the way `LinearReward` already does, and skipping the check when an environment does not declare one;
  * `gamma` in `[0, 1]` and `epsilon > 0` in `MONormalizeReward`;
  * `min_r <= max_r` in `MOClipReward`.

  `ValueError` matches what `MOMaxAndSkipObservation` already raises for a bad `skip`.

* `tests/test_wrappers.py` — regression tests for each case, plus tests that the valid range still works.

Nothing that worked before is rejected: negative indices keep their usual Python meaning and only genuinely out-of-range values raise, `gamma=0` and `gamma=1` are both still accepted, and `min_r == max_r` stays valid as a way to pin a component.

## Verification

`tests/`: **158 passed** with the change against 137 on an unmodified checkout — the 21 new cases and nothing else. The seven pre-existing failures are identical before and after, name for name; they are the `mo-lunar-lander` determinism and equivalence tests, unrelated to this change.

With the fix reverted and the tests kept, 13 of them fail, so they detect the defects rather than passing regardless.

`black`, `isort`, `flake8`, `codespell` and `pydocstyle --convention=google` are clean on both files.
